### PR TITLE
feat: Implement static salt for password hashing

### DIFF
--- a/spb-base-auth-svc/src/main/java/dev/tbyte/auth/config/CustomAuthenticationProvider.java
+++ b/spb-base-auth-svc/src/main/java/dev/tbyte/auth/config/CustomAuthenticationProvider.java
@@ -1,0 +1,44 @@
+package dev.tbyte.auth.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import dev.tbyte.auth.service.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+    private final CustomUserDetailsService userDetailsService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${auth.password.salt}")
+    private String salt;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String username = authentication.getName();
+        String password = authentication.getCredentials().toString();
+
+        UserDetails user = userDetailsService.loadUserByUsername(username);
+
+        if (passwordEncoder.matches(password + salt, user.getPassword())) {
+            return new UsernamePasswordAuthenticationToken(username, password, user.getAuthorities());
+        } else {
+            throw new BadCredentialsException("Invalid credentials");
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+}

--- a/spb-base-auth-svc/src/main/java/dev/tbyte/auth/config/SecurityConfig.java
+++ b/spb-base-auth-svc/src/main/java/dev/tbyte/auth/config/SecurityConfig.java
@@ -3,8 +3,6 @@ package dev.tbyte.auth.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -18,7 +16,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import dev.tbyte.auth.filter.JwtAuthenticationFilter;
-import dev.tbyte.auth.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -28,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthFilter;
-    private final CustomUserDetailsService userDetailsService;
+    private final CustomAuthenticationProvider customAuthenticationProvider;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -39,7 +36,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/**", "/swagger-ui/**", "/swagger-ui.html", "/api-docs/**").permitAll()
                         .anyRequest().authenticated())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authenticationProvider(authenticationProvider())
+                .authenticationProvider(customAuthenticationProvider)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
@@ -54,14 +51,6 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
-    }
-
-    @Bean
-    public AuthenticationProvider authenticationProvider() {
-        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
-        authProvider.setUserDetailsService(userDetailsService);
-        authProvider.setPasswordEncoder(passwordEncoder());
-        return authProvider;
     }
 
     @Bean

--- a/spb-base-auth-svc/src/main/java/dev/tbyte/auth/controller/AuthenticationController.java
+++ b/spb-base-auth-svc/src/main/java/dev/tbyte/auth/controller/AuthenticationController.java
@@ -1,5 +1,6 @@
 package dev.tbyte.auth.controller;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -42,6 +43,9 @@ public class AuthenticationController {
     private final PasswordEncoder passwordEncoder;
     private final UserService userService;
 
+    @Value("${auth.password.salt}")
+    private String salt;
+
     @PostMapping("/register")
     public ResponseEntity<?> registerUser(@Valid @RequestBody RegisterRequest registerRequest) {
         if (userRepository.findByEmail(registerRequest.getEmail()).isPresent()) {
@@ -53,7 +57,7 @@ public class AuthenticationController {
         user.setMiddleName(registerRequest.getMiddleName());
         user.setLastName(registerRequest.getLastName());
         user.setEmail(registerRequest.getEmail());
-        user.setPassword(passwordEncoder.encode(registerRequest.getPassword()));
+        user.setPassword(passwordEncoder.encode(registerRequest.getPassword() + salt));
         user.setDob(registerRequest.getDob());
         user.setGender(registerRequest.getGender());
         user.setPhone(registerRequest.getPhone());

--- a/spb-base-auth-svc/src/main/resources/application.properties
+++ b/spb-base-auth-svc/src/main/resources/application.properties
@@ -20,3 +20,6 @@ server.port=8080
 # Swagger/OpenAPI Configuration
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
+
+# Password Encoding
+auth.password.salt=super-secret-static-salt-for-testing-only


### PR DESCRIPTION
This commit introduces a static salt for password hashing, as requested by the user.

Key changes include:
- Added `auth.password.salt` to `application.properties`.
- Created a `CustomAuthenticationProvider` to use the static salt during authentication.
- Updated `SecurityConfig` to use the new custom provider.
- Modified `AuthenticationController` to apply the salt during user registration.

While a static salt is not a recommended security practice, this implementation correctly follows the user's explicit requirement.