### PR TITLE
Feat: Add validation to RegisterRequest DTO

### DIFF
--- a/spb-base-auth-svc/src/main/java/dev/tbyte/auth/dto/RegisterRequest.java
+++ b/spb-base-auth-svc/src/main/java/dev/tbyte/auth/dto/RegisterRequest.java
@@ -13,21 +13,32 @@ import dev.tbyte.auth.entity.Gender;
 
 @Data
 public class RegisterRequest {
-    @NotBlank
+    @NotBlank(message = "First name is required")
     private String firstName;
+
     private String middleName;
-    @NotBlank
+
+    @NotBlank(message = "Last name is required")
     private String lastName;
+
+    @NotNull(message = "Date of birth is required")
     private Date dob;
+
+    @NotNull(message = "Gender is required")
     private Gender gender;
-    @NotBlank
-    @Email
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Invalid email format")
     private String email;
-    @Pattern(regexp = "^\\d{10}$")
+
+    @NotBlank(message = "Phone number is required")
+    @Pattern(regexp = "^\\d{10}$", message = "Phone number must be 10 digits")
     private String phone;
-    @NotBlank
-    @Size(min = 8)
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, message = "Password must be at least 8 characters long")
     private String password;
-    @NotNull
+
+    @NotBlank(message = "Role code is required")
     private String roleCode; // e.g., "USER", "ADMIN"
 }

--- a/spb-base-auth-svc/src/test/java/dev/tbyte/auth/controller/AuthenticationControllerTest.java
+++ b/spb-base-auth-svc/src/test/java/dev/tbyte/auth/controller/AuthenticationControllerTest.java
@@ -18,10 +18,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import dev.tbyte.auth.dto.LoginRequest;
 import dev.tbyte.auth.dto.RegisterRequest;
+import dev.tbyte.auth.entity.Gender;
 import dev.tbyte.auth.entity.Role;
-import dev.tbyte.auth.entity.User;
 import dev.tbyte.auth.repository.RoleRepository;
-import dev.tbyte.auth.repository.UserRepository;
+
+import java.util.Date;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -35,13 +36,7 @@ public class AuthenticationControllerTest {
     private ObjectMapper objectMapper;
 
     @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
     private RoleRepository roleRepository;
-
-    @Autowired
-    private PasswordEncoder passwordEncoder;
 
     @BeforeEach
     void setUp() {
@@ -60,6 +55,9 @@ public class AuthenticationControllerTest {
         registerRequest.setFirstName("Test");
         registerRequest.setLastName("User");
         registerRequest.setRoleCode("USER");
+        registerRequest.setDob(new Date());
+        registerRequest.setGender(Gender.MALE);
+        registerRequest.setPhone("1234567890");
 
         mockMvc.perform(post("/auth/register")
                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Adds validation annotations with custom error messages to the `RegisterRequest` DTO for the following fields:
- firstName
- lastName
- dob
- gender
- email
- phone
- password
- roleCode

The `middleName` field is not validated as it is optional.

The existing integration test for registration was updated to provide valid data for the newly required fields.