### PR TITLE
feat: Add password confirmation to user services

### DIFF
--- a/spb-base-auth-svc/src/main/java/dev/tbyte/auth/controller/UserController.java
+++ b/spb-base-auth-svc/src/main/java/dev/tbyte/auth/controller/UserController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 import dev.tbyte.auth.dto.UserDto;
 import dev.tbyte.auth.service.UserService;
+import jakarta.validation.Valid;
 
 import java.util.List;
 
@@ -22,7 +23,7 @@ public class UserController {
 
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<UserDto> createUser(@RequestBody UserDto userDto) {
+    public ResponseEntity<UserDto> createUser(@Valid @RequestBody UserDto userDto) {
         return new ResponseEntity<>(userService.createUser(userDto), HttpStatus.CREATED);
     }
 

--- a/spb-base-auth-svc/src/main/java/dev/tbyte/auth/dto/RegisterRequest.java
+++ b/spb-base-auth-svc/src/main/java/dev/tbyte/auth/dto/RegisterRequest.java
@@ -10,8 +10,11 @@ import lombok.Data;
 import java.util.Date;
 
 import dev.tbyte.auth.entity.Gender;
+import dev.tbyte.auth.validation.PasswordMatches;
+import jakarta.validation.constraints.NotBlank;
 
 @Data
+@PasswordMatches
 public class RegisterRequest {
     @NotBlank(message = "First name is required")
     private String firstName;
@@ -38,6 +41,9 @@ public class RegisterRequest {
     @NotBlank(message = "Password is required")
     @Size(min = 8, message = "Password must be at least 8 characters long")
     private String password;
+
+    @NotBlank(message = "Confirm password is required")
+    private String confirmPassword;
 
     @NotBlank(message = "Role code is required")
     private String roleCode; // e.g., "USER", "ADMIN"

--- a/spb-base-auth-svc/src/main/java/dev/tbyte/auth/dto/UserDto.java
+++ b/spb-base-auth-svc/src/main/java/dev/tbyte/auth/dto/UserDto.java
@@ -4,11 +4,13 @@ import dev.tbyte.auth.entity.Gender;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import dev.tbyte.auth.validation.PasswordMatches;
 import lombok.Data;
 
 import java.util.Date;
 
 @Data
+@PasswordMatches
 public class UserDto {
     private Long id;
 
@@ -29,6 +31,12 @@ public class UserDto {
 
     @Pattern(regexp = "^\\d{10}$", message = "Phone number must be 10 digits")
     private String phone;
+
+    @NotBlank(message = "Password is required")
+    private String password;
+
+    @NotBlank(message = "Confirm password is required")
+    private String confirmPassword;
 
     private String roleCode;
 }

--- a/spb-base-auth-svc/src/main/java/dev/tbyte/auth/service/UserServiceImpl.java
+++ b/spb-base-auth-svc/src/main/java/dev/tbyte/auth/service/UserServiceImpl.java
@@ -22,12 +22,13 @@ public class UserServiceImpl implements UserService {
     private final RoleRepository roleRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @org.springframework.beans.factory.annotation.Value("${auth.password.salt}")
+    private String salt;
+
     @Override
     public UserDto createUser(UserDto userDto) {
         User user = toEntity(userDto);
-        // Note: Password should be set via a registration process, not directly here.
-        // This method is for admin-level user creation.
-        user.setPassword(passwordEncoder.encode("default-password")); // Or handle password differently
+        user.setPassword(passwordEncoder.encode(userDto.getPassword() + salt));
         User savedUser = userRepository.save(user);
         return toDto(savedUser);
     }

--- a/spb-base-auth-svc/src/main/java/dev/tbyte/auth/validation/PasswordMatches.java
+++ b/spb-base-auth-svc/src/main/java/dev/tbyte/auth/validation/PasswordMatches.java
@@ -1,0 +1,22 @@
+package dev.tbyte.auth.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = PasswordMatchesValidator.class)
+@Documented
+public @interface PasswordMatches {
+    String message() default "Passwords don't match";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/spb-base-auth-svc/src/main/java/dev/tbyte/auth/validation/PasswordMatchesValidator.java
+++ b/spb-base-auth-svc/src/main/java/dev/tbyte/auth/validation/PasswordMatchesValidator.java
@@ -1,0 +1,27 @@
+package dev.tbyte.auth.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.beans.BeanWrapperImpl;
+
+public class PasswordMatchesValidator implements ConstraintValidator<PasswordMatches, Object> {
+
+    @Override
+    public void initialize(PasswordMatches constraintAnnotation) {
+        // No initialization needed
+    }
+
+    @Override
+    public boolean isValid(Object obj, ConstraintValidatorContext context) {
+        Object passwordValue = new BeanWrapperImpl(obj)
+                .getPropertyValue("password");
+        Object confirmPasswordValue = new BeanWrapperImpl(obj)
+                .getPropertyValue("confirmPassword");
+
+        if (passwordValue != null) {
+            return passwordValue.equals(confirmPasswordValue);
+        } else {
+            return confirmPasswordValue == null;
+        }
+    }
+}

--- a/spb-base-auth-svc/src/test/java/dev/tbyte/auth/controller/AuthenticationControllerTest.java
+++ b/spb-base-auth-svc/src/test/java/dev/tbyte/auth/controller/AuthenticationControllerTest.java
@@ -52,6 +52,7 @@ public class AuthenticationControllerTest {
         RegisterRequest registerRequest = new RegisterRequest();
         registerRequest.setEmail("testuser@example.com");
         registerRequest.setPassword("password123");
+        registerRequest.setConfirmPassword("password123");
         registerRequest.setFirstName("Test");
         registerRequest.setLastName("User");
         registerRequest.setRoleCode("USER");


### PR DESCRIPTION
This commit introduces password confirmation validation for all user creation and update services in the `spb-base-auth-svc`.

Key changes include:
- A custom `@PasswordMatches` annotation and `PasswordMatchesValidator` for cross-field password validation.
- The `confirmPassword` field has been added to `RegisterRequest` and `UserDto`.
- The `@PasswordMatches` annotation has been applied to both DTOs to enforce validation.
- The `UserController` now validates the `UserDto` when creating users.
- The `UserService` has been updated to handle the password from the `UserDto`, including the user-requested manual salting.
- The `AuthenticationControllerTest` has been updated to include the `confirmPassword` field.